### PR TITLE
[METAL] Fix deferred memory release in Metal runtime

### DIFF
--- a/src/auto_scheduler/search_policy/sketch_policy_rules.cc
+++ b/src/auto_scheduler/search_policy/sketch_policy_rules.cc
@@ -164,6 +164,8 @@ SketchGenerationRule::ConditionKind RuleAddCacheRead::MeetCondition(const Sketch
   // Don't cache_read a stage if it has multiple consumers
   const std::set<int>& consumers = GetConsumers(task, state, stage_id);
 
+  if (consumers.size() == 0)
+    return ConditionKind::kSkip;
   // Don't cache_read a stage if its consumer does not need multi-level tiling
   int target_stage_id = *consumers.begin();
   if (!NeedsMultilevelTiling(task, state, target_stage_id)) {

--- a/src/runtime/contrib/random/mt_random_engine.cc
+++ b/src/runtime/contrib/random/mt_random_engine.cc
@@ -126,8 +126,10 @@ class RandomEngine {
     } else {
       runtime::NDArray local = runtime::NDArray::Empty(
           std::vector<int64_t>{data->shape, data->shape + data->ndim}, data->dtype, {kDLCPU, 0});
-      FillData(&local.ToDLPack()->dl_tensor, size);
-      runtime::NDArray::CopyFromTo(&local.ToDLPack()->dl_tensor, data);
+      DLManagedTensor* dmt = local.ToDLPack();
+      FillData(&dmt->dl_tensor, size);
+      runtime::NDArray::CopyFromTo(&dmt->dl_tensor, data);
+      dmt->deleter(dmt);
     }
   }
 

--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -98,15 +98,23 @@ kernel void CopyKernel(
 // But we keep this code.
 int GetWarpSize(id<MTLDevice> dev) {
   NSError* error_msg = nil;
-  id<MTLLibrary> lib = [dev newLibraryWithSource:[NSString stringWithUTF8String:kDummyKernel]
-                                         options:nil
-                                           error:&error_msg];
-  ICHECK(lib != nil) << [[error_msg localizedDescription] UTF8String];
-  id<MTLFunction> f = [lib newFunctionWithName:[NSString stringWithUTF8String:"CopyKernel"]];
-  ICHECK(f != nil);
-  id<MTLComputePipelineState> state = [dev newComputePipelineStateWithFunction:f error:&error_msg];
-  ICHECK(state != nil) << [[error_msg localizedDescription] UTF8String];
-  return static_cast<int>(state.threadExecutionWidth);
+  int size = 0;
+  @autoreleasepool {
+    id<MTLLibrary> lib = [dev newLibraryWithSource:[NSString stringWithUTF8String:kDummyKernel]
+                                           options:nil
+                                             error:&error_msg];
+    ICHECK(lib != nil) << [[error_msg localizedDescription] UTF8String];
+    id<MTLFunction> f = [lib newFunctionWithName:[NSString stringWithUTF8String:"CopyKernel"]];
+    ICHECK(f != nil);
+    id<MTLComputePipelineState> state = [dev newComputePipelineStateWithFunction:f
+                                                                           error:&error_msg];
+    ICHECK(state != nil) << [[error_msg localizedDescription] UTF8String];
+    size = static_cast<int>(state.threadExecutionWidth);
+    [state release];
+    [f release];
+    [lib release];
+  }
+  return size;
 }
 
 MetalWorkspace::~MetalWorkspace() {
@@ -180,59 +188,61 @@ void MetalWorkspace::CopyDataFromTo(const void* from, size_t from_offset, void* 
   TVMContext ctx = ctx_from;
   if (ctx_from.device_type == kDLCPU) ctx = ctx_to;
   id<MTLCommandQueue> queue = GetCommandQueue(ctx);
-  id<MTLCommandBuffer> cb = [queue commandBuffer];
-  int from_dev_type = static_cast<int>(ctx_from.device_type);
-  int to_dev_type = static_cast<int>(ctx_to.device_type);
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [queue commandBuffer];
+    int from_dev_type = static_cast<int>(ctx_from.device_type);
+    int to_dev_type = static_cast<int>(ctx_to.device_type);
 
-  if (from_dev_type == kDLMetal && to_dev_type == kDLMetal) {
-    ICHECK_EQ(ctx_from.device_id, ctx_to.device_id) << "Metal disallow cross device copy.";
-    id<MTLBlitCommandEncoder> encoder = [cb blitCommandEncoder];
-    [encoder copyFromBuffer:(__bridge id<MTLBuffer>)(from)
-               sourceOffset:from_offset
-                   toBuffer:(__bridge id<MTLBuffer>)(to)destinationOffset:to_offset
-                       size:size];
-    [encoder endEncoding];
-    [cb commit];
-  } else if (from_dev_type == kDLMetal && to_dev_type == kDLCPU) {
-    // copy to a local buffer before get into global buffer.
-    id<MTLBuffer> from_buf = (__bridge id<MTLBuffer>)(from);
-    if (from_buf.storageMode != MTLStorageModeShared) {
-      id<MTLBuffer> temp = MetalThreadEntry::ThreadLocal()->GetTempBuffer(ctx_from, size);
+    if (from_dev_type == kDLMetal && to_dev_type == kDLMetal) {
+      ICHECK_EQ(ctx_from.device_id, ctx_to.device_id) << "Metal disallow cross device copy.";
       id<MTLBlitCommandEncoder> encoder = [cb blitCommandEncoder];
-      [encoder copyFromBuffer:from_buf
+      [encoder copyFromBuffer:(__bridge id<MTLBuffer>)(from)
                  sourceOffset:from_offset
-                     toBuffer:temp
-            destinationOffset:0
+                     toBuffer:(__bridge id<MTLBuffer>)(to)destinationOffset:to_offset
                          size:size];
       [encoder endEncoding];
       [cb commit];
-      [cb waitUntilCompleted];
-      memcpy(static_cast<char*>(to) + to_offset, static_cast<char*>([temp contents]), size);
+    } else if (from_dev_type == kDLMetal && to_dev_type == kDLCPU) {
+      // copy to a local buffer before get into global buffer.
+      id<MTLBuffer> from_buf = (__bridge id<MTLBuffer>)(from);
+      if (from_buf.storageMode != MTLStorageModeShared) {
+        id<MTLBuffer> temp = MetalThreadEntry::ThreadLocal()->GetTempBuffer(ctx_from, size);
+        id<MTLBlitCommandEncoder> encoder = [cb blitCommandEncoder];
+        [encoder copyFromBuffer:from_buf
+                   sourceOffset:from_offset
+                       toBuffer:temp
+              destinationOffset:0
+                           size:size];
+        [encoder endEncoding];
+        [cb commit];
+        [cb waitUntilCompleted];
+        memcpy(static_cast<char*>(to) + to_offset, static_cast<char*>([temp contents]), size);
+      } else {
+        memcpy(static_cast<char*>(to) + to_offset,
+               static_cast<char*>([from_buf contents]) + from_offset, size);
+      }
+    } else if (from_dev_type == kDLCPU && to_dev_type == kDLMetal) {
+      id<MTLBuffer> to_buf = (__bridge id<MTLBuffer>)(to);
+      if (to_buf.storageMode != MTLStorageModeShared) {
+        id<MTLBuffer> temp = MetalThreadEntry::ThreadLocal()->GetTempBuffer(ctx_to, size);
+        memcpy([temp contents], static_cast<const char*>(from) + from_offset, size);
+        id<MTLBlitCommandEncoder> encoder = [cb blitCommandEncoder];
+        [encoder copyFromBuffer:temp
+                   sourceOffset:0
+                       toBuffer:to_buf
+              destinationOffset:to_offset
+                           size:size];
+        [encoder endEncoding];
+        [cb commit];
+        [cb waitUntilCompleted];
+      } else {
+        memcpy(static_cast<char*>([to_buf contents]) + to_offset,
+               static_cast<const char*>(from) + from_offset, size);
+      }
     } else {
-      memcpy(static_cast<char*>(to) + to_offset,
-             static_cast<char*>([from_buf contents]) + from_offset, size);
+      LOG(FATAL) << "Expect copy from/to Metal or between Metal"
+                 << ", from=" << from_dev_type << ", to=" << to_dev_type;
     }
-  } else if (from_dev_type == kDLCPU && to_dev_type == kDLMetal) {
-    id<MTLBuffer> to_buf = (__bridge id<MTLBuffer>)(to);
-    if (to_buf.storageMode != MTLStorageModeShared) {
-      id<MTLBuffer> temp = MetalThreadEntry::ThreadLocal()->GetTempBuffer(ctx_to, size);
-      memcpy([temp contents], static_cast<const char*>(from) + from_offset, size);
-      id<MTLBlitCommandEncoder> encoder = [cb blitCommandEncoder];
-      [encoder copyFromBuffer:temp
-                 sourceOffset:0
-                     toBuffer:to_buf
-            destinationOffset:to_offset
-                         size:size];
-      [encoder endEncoding];
-      [cb commit];
-      [cb waitUntilCompleted];
-    } else {
-      memcpy(static_cast<char*>([to_buf contents]) + to_offset,
-             static_cast<const char*>(from) + from_offset, size);
-    }
-  } else {
-    LOG(FATAL) << "Expect copy from/to Metal or between Metal"
-               << ", from=" << from_dev_type << ", to=" << to_dev_type;
   }
 }
 
@@ -240,9 +250,11 @@ void MetalWorkspace::StreamSync(TVMContext ctx, TVMStreamHandle stream) {
   ICHECK(stream == nullptr);
   // commit an empty command buffer and wait until it completes.
   id<MTLCommandQueue> queue = GetCommandQueue(ctx);
-  id<MTLCommandBuffer> cb = [queue commandBuffer];
-  [cb commit];
-  [cb waitUntilCompleted];
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [queue commandBuffer];
+    [cb commit];
+    [cb waitUntilCompleted];
+  }
 }
 
 void* MetalWorkspace::AllocWorkspace(TVMContext ctx, size_t size, DLDataType type_hint) {

--- a/src/runtime/metal/metal_module.mm
+++ b/src/runtime/metal/metal_module.mm
@@ -210,6 +210,8 @@ class MetalWrappedFunc {
       // launch
       MTLSize dimGrid = MTLSizeMake(wl.grid_dim(0), wl.grid_dim(1), wl.grid_dim(2));
       MTLSize dimBlock = MTLSizeMake(wl.block_dim(0), wl.block_dim(1), wl.block_dim(2));
+      int blockSize = wl.block_dim(0) * wl.block_dim(1) * wl.block_dim(2);
+      CHECK_LE(blockSize, scache_[device_id].maxTotalThreadsPerThreadgroup);
       [encoder dispatchThreadgroups:dimGrid threadsPerThreadgroup:dimBlock];
       [encoder endEncoding];
       [cb commit];

--- a/src/runtime/metal/metal_module.mm
+++ b/src/runtime/metal/metal_module.mm
@@ -85,56 +85,52 @@ class MetalModuleNode final : public runtime::ModuleNode {
     if (it != e.smap.end()) return it->second;
     // compile
     NSError* err_msg = nil;
-    @autoreleasepool {
-      if (e.lib == nil) {
-        if (fmt_ == "metal") {
-          MTLCompileOptions* opts = [MTLCompileOptions alloc];
-          opts.languageVersion = MTLLanguageVersion2_3;
-          opts.fastMathEnabled = YES;
-          // opts = nil;
-          e.lib = [w->devices[device_id]
-              newLibraryWithSource:[NSString stringWithUTF8String:data_.c_str()]
-                           options:opts
-                             error:&err_msg];
-          [opts dealloc];
-          if (e.lib == nil) {
-            LOG(FATAL) << "Fail to compile metal lib:"
-                       << [[err_msg localizedDescription] UTF8String];
-          }
-          if (err_msg != nil) {
-            LOG(INFO) << "Warning: " << [[err_msg localizedDescription] UTF8String];
-          }
-        } else {
-          // Build from library.
-          auto q = dispatch_queue_create("q", DISPATCH_QUEUE_SERIAL);
-          auto data = dispatch_data_create(data_.c_str(), data_.length(), q,
-                                           ^{
-                                           });
-          e.lib = [w->devices[device_id] newLibraryWithData:data error:&err_msg];
-          if (err_msg != nil || e.lib == nil) {
-            LOG(FATAL) << "Fail to compile metal lib:"
-                       << [[err_msg localizedDescription] UTF8String];
-          }
+    if (e.lib == nil) {
+      if (fmt_ == "metal") {
+        MTLCompileOptions* opts = [MTLCompileOptions alloc];
+        opts.languageVersion = MTLLanguageVersion2_3;
+        opts.fastMathEnabled = YES;
+        // opts = nil;
+        e.lib = [w->devices[device_id]
+            newLibraryWithSource:[NSString stringWithUTF8String:data_.c_str()]
+                         options:opts
+                           error:&err_msg];
+        [opts dealloc];
+        if (e.lib == nil) {
+          LOG(FATAL) << "Fail to compile metal lib:" << [[err_msg localizedDescription] UTF8String];
+        }
+        if (err_msg != nil) {
+          LOG(INFO) << "Warning: " << [[err_msg localizedDescription] UTF8String];
+        }
+      } else {
+        // Build from library.
+        auto q = dispatch_queue_create("q", DISPATCH_QUEUE_SERIAL);
+        auto data = dispatch_data_create(data_.c_str(), data_.length(), q,
+                                         ^{
+                                         });
+        e.lib = [w->devices[device_id] newLibraryWithData:data error:&err_msg];
+        if (err_msg != nil || e.lib == nil) {
+          LOG(FATAL) << "Fail to compile metal lib:" << [[err_msg localizedDescription] UTF8String];
         }
       }
-      id<MTLFunction> f =
-          [e.lib newFunctionWithName:[NSString stringWithUTF8String:func_name.c_str()]];
-      ICHECK(f != nil) << "cannot find function " << func_name;
-      std::cout << "before newComputePipelineStateWithFunction, func: " << func_name << std::endl;
-      id<MTLComputePipelineState> state =
-          [w->devices[device_id] newComputePipelineStateWithFunction:f error:&err_msg];
-      ICHECK(state != nil) << "cannot get state:"
-                           << " for function " << func_name
-                           << [[err_msg localizedDescription] UTF8String];
-      [f release];
-      // The state.threadExecutionWidth can change dynamically according
-      // to the resource constraint in kernel, so it is not strictly hold
-      // Turn of warp aware optimziation for now.
-      // ICHECK_EQ(state.threadExecutionWidth, w->warp_size[device_id]);
-      if (e.smap[func_name] != nil) [e.smap[func_name] release];
-      e.smap[func_name] = state;
-      return state;
     }
+    id<MTLFunction> f =
+        [e.lib newFunctionWithName:[NSString stringWithUTF8String:func_name.c_str()]];
+    ICHECK(f != nil) << "cannot find function " << func_name;
+    std::cout << "before newComputePipelineStateWithFunction, func: " << func_name << std::endl;
+    id<MTLComputePipelineState> state =
+        [w->devices[device_id] newComputePipelineStateWithFunction:f error:&err_msg];
+    ICHECK(state != nil) << "cannot get state:"
+                         << " for function " << func_name
+                         << [[err_msg localizedDescription] UTF8String];
+    [f release];
+    // The state.threadExecutionWidth can change dynamically according
+    // to the resource constraint in kernel, so it is not strictly hold
+    // Turn of warp aware optimziation for now.
+    // ICHECK_EQ(state.threadExecutionWidth, w->warp_size[device_id]);
+    if (e.smap[func_name] != nil) [e.smap[func_name] release];
+    e.smap[func_name] = state;
+    return state;
   }
 
  private:
@@ -187,23 +183,23 @@ class MetalWrappedFunc {
   }
   // invoke the function with void arguments
   void operator()(TVMArgs args, TVMRetValue* rv, const ArgUnion* pack_args) const {
-    metal::MetalThreadEntry* t = metal::MetalThreadEntry::ThreadLocal();
-    int device_id = t->context.device_id;
-    if (scache_[device_id] == nil) {
-      scache_[device_id] = m_->GetPipelineState(device_id, func_name_);
-    }
-    ThreadWorkLoad wl = thread_axis_cfg_.Extract(args);
-    int blockSize = wl.block_dim(0) * wl.block_dim(1) * wl.block_dim(2);
-    auto maxTotalThreadsPerThreadgroup = scache_[device_id].maxTotalThreadsPerThreadgroup;
-    CHECK_LE(blockSize, maxTotalThreadsPerThreadgroup);
-    id<MTLCommandQueue> queue = w_->GetCommandQueue(t->context);
     @autoreleasepool {
+      metal::MetalThreadEntry* t = metal::MetalThreadEntry::ThreadLocal();
+      int device_id = t->context.device_id;
+      if (scache_[device_id] == nil) {
+        scache_[device_id] = m_->GetPipelineState(device_id, func_name_);
+      }
+      ThreadWorkLoad wl = thread_axis_cfg_.Extract(args);
+      int blockSize = wl.block_dim(0) * wl.block_dim(1) * wl.block_dim(2);
+      auto maxTotalThreadsPerThreadgroup = scache_[device_id].maxTotalThreadsPerThreadgroup;
+      CHECK_LE(blockSize, maxTotalThreadsPerThreadgroup);
+      id<MTLCommandQueue> queue = w_->GetCommandQueue(t->context);
       id<MTLCommandBuffer> cb = [queue commandBuffer];
       id<MTLComputeCommandEncoder> encoder = [cb computeCommandEncoder];
       [encoder setComputePipelineState:scache_[device_id]];
       for (size_t i = 0; i < num_buffer_args_; ++i) {
         void* buf = args[static_cast<int>(i)];
-        [encoder setBuffer:(__bridge id<MTLBuffer>)(buf) offset:0 atIndex:i];
+        [encoder setBuffer:(id<MTLBuffer>)(buf) offset:0 atIndex:i];
       }
       if (num_pack_args_ != 0) {
         [encoder setBytes:pack_args
@@ -241,23 +237,27 @@ class MetalWrappedFunc {
 
 PackedFunc MetalModuleNode::GetFunction(const std::string& name,
                                         const ObjectPtr<Object>& sptr_to_self) {
-  ICHECK_EQ(sptr_to_self.get(), this);
-  ICHECK_NE(name, symbol::tvm_module_main) << "Device function do not have main";
-  auto it = fmap_.find(name);
-  if (it == fmap_.end()) return PackedFunc();
-  const FunctionInfo& info = it->second;
-  MetalWrappedFunc f;
-  size_t num_buffer_args = NumBufferArgs(info.arg_types);
-  f.Init(this, sptr_to_self, name, num_buffer_args, info.arg_types.size() - num_buffer_args,
-         info.thread_axis_tags);
-  return PackFuncNonBufferArg(f, info.arg_types);
+  @autoreleasepool {
+    ICHECK_EQ(sptr_to_self.get(), this);
+    ICHECK_NE(name, symbol::tvm_module_main) << "Device function do not have main";
+    auto it = fmap_.find(name);
+    if (it == fmap_.end()) return PackedFunc();
+    const FunctionInfo& info = it->second;
+    MetalWrappedFunc f;
+    size_t num_buffer_args = NumBufferArgs(info.arg_types);
+    f.Init(this, sptr_to_self, name, num_buffer_args, info.arg_types.size() - num_buffer_args,
+           info.thread_axis_tags);
+    return PackFuncNonBufferArg(f, info.arg_types);
+  }
 }
 
 Module MetalModuleCreate(std::string data, std::string fmt,
                          std::unordered_map<std::string, FunctionInfo> fmap, std::string source) {
-  metal::MetalWorkspace::Global()->Init();
-  auto n = make_object<MetalModuleNode>(data, fmt, fmap, source);
-  return Module(n);
+  @autoreleasepool {
+    metal::MetalWorkspace::Global()->Init();
+    auto n = make_object<MetalModuleNode>(data, fmt, fmap, source);
+    return Module(n);
+  }
 }
 
 // Load module from module.


### PR DESCRIPTION
In case when we build runtime without ARC, we can have problems with
memory releasing. Due to some of Objective-C methods returns
autoreleased pointers, we should specify `autoreleasepool` blocks to
determine life cycle of these pointers.

Without this fix I had have a problem that memory was over when a
topology was executed multiple times.

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
