### PR TITLE
[MSFT] Workaround for BNNS compilation

### DIFF
--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -276,7 +276,8 @@ bool DFPatternMatcher::VisitDFPattern_(const CallPatternNode* op, const Expr& ex
       }
       // Commutative Matching
       if (const OpNode* op_node = get_op_node(op)) {
-        if ((op_node->name == "add") || (op_node->name == "multiply")) {
+//        if ((op_node->name == "add") || (op_node->name == "multiply")) {
+        if ((op_node->name == "multiply")) {
           if (match_args(reverse(op->args), call_node->args)) {
             return true;
           }


### PR DESCRIPTION
For two models (`aec`, `cruse`) it was not possible to apply `BNNS`. The script for compiling the model stops working with an error when executing the `partition_for_bnns` function. This is due to the fact that the `check_dense` function does not take into account the fact that the operator can be `commutative` (an internal assumption, which in our case was not fulfilled).

These changes are a `workaround` for this problem.

The following `error` occurred while compiling models:

```bash
Traceback (most recent call last):
  File "/Users/agladyshev/workspace/tvm-samples/deploy_flows/flow3c/compile_local_cpu_no_tune.py", line 48, in <module>
    mod = partition_for_bnns(mod)
  File "/Users/agladyshev/workspace/tvm/python/tvm/relay/op/contrib/bnns.py", line 73, in partition_for_bnns
    return seq(mod)
  File "/Users/agladyshev/workspace/tvm/python/tvm/ir/transform.py", line 127, in __call__
    return _ffi_transform_api.RunPass(self, mod)
  File "/Users/agladyshev/workspace/tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 237, in __call__
    raise get_last_ffi_error()
AttributeError: Traceback (most recent call last):
  [bt] (8) 9   libtvm.dylib                        0x000000011a94b498 tvm::runtime::TVMRetValue tvm::runtime::PackedFunc::operator()<tvm::RelayExpr const&>(tvm::RelayExpr const&) const + 232
  [bt] (7) 8   libtvm.dylib                        0x00000001186f8d51 std::__1::function<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const + 65
  [bt] (6) 7   libtvm.dylib                        0x00000001186f8f8a std::__1::__function::__value_func<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs&&, tvm::runtime::TVMRetValue*&&) const + 106
  [bt] (5) 6   libtvm.dylib                        0x000000011b57e738 std::__1::__function::__func<TVMFuncCreateFromCFunc::$_2, std::__1::allocator<TVMFuncCreateFromCFunc::$_2>, void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs&&, tvm::runtime::TVMRetValue*&&) + 72
  [bt] (4) 5   libtvm.dylib                        0x000000011b57fc67 std::__1::__function::__alloc_func<TVMFuncCreateFromCFunc::$_2, std::__1::allocator<TVMFuncCreateFromCFunc::$_2>, void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs&&, tvm::runtime::TVMRetValue*&&) + 71
  [bt] (3) 4   libtvm.dylib                        0x000000011b57fcb7 void std::__1::__invoke_void_return_wrapper<void>::__call<TVMFuncCreateFromCFunc::$_2&, tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*>(TVMFuncCreateFromCFunc::$_2&, tvm::runtime::TVMArgs&&, tvm::runtime::TVMRetValue*&&) + 71
  [bt] (2) 3   libtvm.dylib                        0x000000011b57fd53 decltype(std::__1::forward<TVMFuncCreateFromCFunc::$_2&>(fp)(std::__1::forward<tvm::runtime::TVMArgs>(fp0), std::__1::forward<tvm::runtime::TVMRetValue*>(fp0))) std::__1::__invoke<TVMFuncCreateFromCFunc::$_2&, tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*>(TVMFuncCreateFromCFunc::$_2&, tvm::runtime::TVMArgs&&, tvm::runtime::TVMRetValue*&&) + 115
  [bt] (1) 2   libtvm.dylib                        0x000000011b57fe24 TVMFuncCreateFromCFunc::$_2::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const + 180
  [bt] (0) 1   libtvm.dylib                        0x000000011b5d8495 tvm::runtime::Backtrace() + 37
  File "/Users/agladyshev/workspace/tvm/python/tvm/runtime/object.py", line 63, in __getattr__
    return _ffi_node_api.NodeGetAttr(self, name)
  File "/Users/agladyshev/workspace/tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 237, in __call__
    raise get_last_ffi_error()
  [bt] (8) 9   libtvm.dylib                        0x0000000118b90c87 std::__1::__function::__alloc_func<void (*)(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*), std::__1::allocator<void (*)(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>, void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs&&, tvm::runtime::TVMRetValue*&&) + 71
  [bt] (7) 8   libtvm.dylib                        0x0000000118b90cd7 void std::__1::__invoke_void_return_wrapper<void>::__call<void (*&)(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*), tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*>(void (*&)(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*), tvm::runtime::TVMArgs&&, tvm::runtime::TVMRetValue*&&) + 71
  [bt] (6) 7   libtvm.dylib                        0x0000000118b90d73 decltype(std::__1::forward<void (*&)(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>(fp)(std::__1::forward<tvm::runtime::TVMArgs>(fp0), std::__1::forward<tvm::runtime::TVMRetValue*>(fp0))) std::__1::__invoke<void (*&)(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*), tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*>(void (*&)(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*), tvm::runtime::TVMArgs&&, tvm::runtime::TVMRetValue*&&) + 115
  [bt] (5) 6   libtvm.dylib                        0x0000000118b7fe11 tvm::NodeGetAttr(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) + 657
  [bt] (4) 5   libtvm.dylib                        0x0000000118b7e136 tvm::ReflectionVTable::GetAttr(tvm::runtime::Object*, tvm::runtime::String const&) const + 1014
  [bt] (3) 4   libtvm.dylib                        0x000000011839f195 tvm::runtime::detail::LogFatal::~LogFatal() + 21
  [bt] (2) 3   libtvm.dylib                        0x00000001183a141d tvm::runtime::detail::LogFatal::~LogFatal() + 29
  [bt] (1) 2   libtvm.dylib                        0x00000001183a14cc tvm::runtime::detail::LogFatal::Entry::Finalize() + 156
  [bt] (0) 1   libtvm.dylib                        0x000000011b5d8495 tvm::runtime::Backtrace() + 37
  File "/Users/agladyshev/workspace/tvm/src/node/reflection.cc", line 110
  File "/Users/agladyshev/workspace/tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 81, in cfun
    rv = local_pyfunc(*pyargs)
  File "/Users/agladyshev/workspace/tvm/python/tvm/relay/op/contrib/bnns.py", line 266, in check_dense
    while call.op.name != "nn.dense":
  File "/Users/agladyshev/workspace/tvm/python/tvm/runtime/object.py", line 65, in __getattr__
    raise AttributeError("%s has no attribute %s" % (str(type(self)), name))
AttributeError: relay.TupleGetItem object has no attributed op
During handling of the above exception, another exception occurred:
AttributeError: <class 'tvm.relay.expr.TupleGetItem'> has no attribute op
```