### PR TITLE
[RPC] Reproducer for RPC session deadlock

### DIFF
--- a/tests/python/contrib/test_bnns/test_rpc_session_deadlock.py
+++ b/tests/python/contrib/test_bnns/test_rpc_session_deadlock.py
@@ -1,0 +1,42 @@
+from tvm import rpc
+from tvm.rpc import tracker
+from tvm.contrib import xcode
+from tvm.autotvm.measure import request_remote
+
+
+KEY = "some_key"
+
+
+class SomeHolder:
+    def __init__(self, host, port):
+        self.field_which_needed_for_deadlock = "arm64"
+        self.deadlock_field = lambda output, objects, **kwargs: xcode.create_dylib(
+            output, objects, arch=self.field_which_needed_for_deadlock
+        )
+        self.remote_session = request_remote(KEY, host, port, timeout=1000)
+
+    def __del__(self):
+        print("No references for {}".format(self))
+
+
+def wrapper_for_object_destruction(host, port):
+    SomeHolder(host, port)
+
+
+def test_rpc_session_deadlock():
+    local_host = "127.0.0.1"
+    tracker_server = tracker.Tracker(local_host, 8888)
+    remote_server = rpc.Server(
+        local_host, port=9099, tracker_addr=(tracker_server.host, tracker_server.port), key=KEY
+    )
+
+    # Problem place
+    for _ in [1, 2]:
+        wrapper_for_object_destruction(tracker_server.host, tracker_server.port)
+
+    remote_server.terminate()
+    tracker_server.terminate()
+
+
+if __name__ == '__main__':
+    test_rpc_session_deadlock()


### PR DESCRIPTION
The problem is that the created object for the `PRC session` was not destroyed when it went out of scope, which caused the tracker to think that the device was busy, and therefore it was impossible to create a new session.

The above code demonstrates this behavior and shows the reason why this is happening.

Cause:
Three fields are created in the special class `SomeHolder`:
* `remote_session` - session, which should be destroyed along with the object `SomeHolder`
* `deadlock_field` - a lambda function that does not destroy the `SomeHolder` object
* `field_which_needed_for_deadlock` - the field that is needed in order for the lambda to be created so that the object is not destroyed (circular reference?)

If you remove the `field_which_needed_for_deadlock` field, there will be no deadlock.
